### PR TITLE
elon-algorithm: allow direct sub-agent run for small artifacts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
     {
       "name": "elon-algorithm",
       "description": "Run Elon's algorithm (question → delete → simplify) on any artifact to cut AI slop and make code, prompts, skills, or docs leaner. Ships a reusable workflow + skill.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "source": "./plugins/elon-algorithm"
     },
     {

--- a/plugins/elon-algorithm/.claude-plugin/plugin.json
+++ b/plugins/elon-algorithm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elon-algorithm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Run Elon's algorithm (question every requirement → delete → simplify) on any artifact to cut AI slop and make code, prompts, skills, or docs leaner and denser. Ships a reusable workflow + an accompanying skill.",
   "author": {
     "name": "Nityesh Agarwal"

--- a/plugins/elon-algorithm/skills/elon-algorithm/SKILL.md
+++ b/plugins/elon-algorithm/skills/elon-algorithm/SKILL.md
@@ -35,7 +35,17 @@ The output is a **plan, not a blind rewrite** — you review it and apply it as 
 
 ## Run it
 
-Invoke the **Workflow** tool with the bundled script:
+The four phases above are the *spirit* of the algorithm, not a tool. How you run them depends on the size of the artifact:
+
+### Small artifact (a single file, or a couple) — run it directly
+
+When the target is one file or a small handful, you **don't need the workflow**. The bird's-eye/cross-file pass exists for multi-file trees; with one or two files there's almost nothing to see across them. Just run the algorithm yourself: clone the target so the original is never touched, then launch sub-agents directly to follow the spirit — e.g. one reviewer per file proposing cuts, one skeptic arguing each cut back (deletion gets the last word), then judge cut-by-default and hand back a cut-plan + ranked add-back menu. Same `clone → review → debate → judge` shape, no dynamic workflow.
+
+This is the lighter, faster default for most "trim this one file/prompt/skill" asks.
+
+### Large or multi-file artifact (a directory, a bundle, a mirror tree) — use the workflow
+
+When the target spans many files — where cross-file redundancy (duplicate docs, mirror trees, a fact stated in three places) is the real prize — invoke the bundled **Workflow**, which orchestrates the full fan-out deterministically:
 
 ```
 Workflow({

--- a/plugins/elon-algorithm/skills/elon-algorithm/SKILL.md
+++ b/plugins/elon-algorithm/skills/elon-algorithm/SKILL.md
@@ -39,13 +39,13 @@ The four phases above are the *spirit* of the algorithm, not a tool. How you run
 
 ### Small artifact (a single file, or a couple) — run it directly
 
-When the target is one file or a small handful, you **don't need the workflow**. The bird's-eye/cross-file pass exists for multi-file trees; with one or two files there's almost nothing to see across them. Just run the algorithm yourself: clone the target so the original is never touched, then launch sub-agents directly to follow the spirit — e.g. one reviewer per file proposing cuts, one skeptic arguing each cut back (deletion gets the last word), then judge cut-by-default and hand back a cut-plan + ranked add-back menu. Same `clone → review → debate → judge` shape, no dynamic workflow.
+When the target is one file or a small handful, you **don't need the workflow**. The bird's-eye/cross-file pass exists for multi-file trees; with one or two files there's almost nothing to see across them. Just run the algorithm yourself: clone the target so the original is never touched, then launch sub-agents directly to follow the spirit — e.g. one reviewer per file proposing cuts/rewrites, one skeptic arguing each cut back (deletion gets the last word), then judge cut-by-default and hand back a cut-plan + ranked add-back menu. Same `clone → review → debate → judge` shape, no dynamic workflow.
 
 This is the lighter, faster default for most "trim this one file/prompt/skill" asks.
 
 ### Large or multi-file artifact (a directory, a bundle, a mirror tree) — use the workflow
 
-When the target spans many files — where cross-file redundancy (duplicate docs, mirror trees, a fact stated in three places) is the real prize — invoke the bundled **Workflow**, which orchestrates the full fan-out deterministically:
+When the target spans many files, invoke the bundled **Workflow**, which orchestrates the full fan-out deterministically:
 
 ```
 Workflow({


### PR DESCRIPTION
## What

The `elon-algorithm` skill's **Run it** section currently mandates invoking the **Workflow** tool for every run. This PR makes the workflow optional based on artifact size.

- **Small artifact (a single file, or a couple)** → run the algorithm *directly*: clone the target, launch sub-agents to follow the same `clone → review → debate → judge` spirit, no dynamic workflow.
- **Large / multi-file artifact (directory, bundle, mirror tree)** → use the bundled Workflow, where the bird's-eye cross-file pass is the real prize.

## Why

The dynamic workflow earns its keep when cross-file redundancy is the point. For one or two files there's almost nothing to see *across* them, so spinning up the full fan-out is overkill — the lighter direct path is the better default for most "trim this one file/prompt/skill" asks. The four phases are the *spirit* of the algorithm, not a tool to always launch.

Bumps `elon-algorithm` 0.1.0 → 0.2.0 (plugin.json + marketplace.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)