### PR TITLE
elon-algorithm: keep the structural altitude on single-file runs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,8 +14,8 @@
     },
     {
       "name": "elon-algorithm",
-      "description": "Run Elon's algorithm (question → delete → simplify) on any artifact to cut AI slop and make code, prompts, skills, or docs leaner. Ships a reusable workflow + skill.",
-      "version": "0.2.0",
+      "description": "Run Elon's algorithm (question \u2192 delete \u2192 simplify) on any artifact to cut AI slop and make code, prompts, skills, or docs leaner. Ships a reusable workflow + skill.",
+      "version": "0.2.1",
       "source": "./plugins/elon-algorithm"
     },
     {

--- a/plugins/elon-algorithm/.claude-plugin/plugin.json
+++ b/plugins/elon-algorithm/.claude-plugin/plugin.json
@@ -1,9 +1,17 @@
 {
   "name": "elon-algorithm",
-  "version": "0.2.0",
-  "description": "Run Elon's algorithm (question every requirement → delete → simplify) on any artifact to cut AI slop and make code, prompts, skills, or docs leaner and denser. Ships a reusable workflow + an accompanying skill.",
+  "version": "0.2.1",
+  "description": "Run Elon's algorithm (question every requirement \u2192 delete \u2192 simplify) on any artifact to cut AI slop and make code, prompts, skills, or docs leaner and denser. Ships a reusable workflow + an accompanying skill.",
   "author": {
     "name": "Nityesh Agarwal"
   },
-  "keywords": ["workflow", "simplify", "ai-slop", "refactor", "leaner", "elon-algorithm", "skill"]
+  "keywords": [
+    "workflow",
+    "simplify",
+    "ai-slop",
+    "refactor",
+    "leaner",
+    "elon-algorithm",
+    "skill"
+  ]
 }

--- a/plugins/elon-algorithm/skills/elon-algorithm/SKILL.md
+++ b/plugins/elon-algorithm/skills/elon-algorithm/SKILL.md
@@ -39,7 +39,7 @@ The four phases above are the *spirit* of the algorithm, not a tool. How you run
 
 ### Small artifact (a single file, or a couple) — run it directly
 
-When the target is one file or a small handful, you **don't need the workflow**. The bird's-eye/cross-file pass exists for multi-file trees; with one or two files there's almost nothing to see across them. Just run the algorithm yourself: clone the target so the original is never touched, then launch sub-agents directly to follow the spirit — e.g. one reviewer per file proposing cuts/rewrites, one skeptic arguing each cut back (deletion gets the last word), then judge cut-by-default and hand back a cut-plan + ranked add-back menu. Same `clone → review → debate → judge` shape, no dynamic workflow.
+When the target is one file or a small handful, you **don't need the workflow** — but the *structural* altitude still applies. The cross-file pass is moot with one file; questioning whether each **section / block / requirement deserves to exist** is not, and that's where the deepest cuts live. So attack structure before copy: default to deleting or merging whole sections, then simplify the survivors line-by-line. **The failure mode is treating the existing structure as fixed and only trimming sentences inside it — a 1% pass, not an Elon pass.** Then run the same `clone → review → debate → judge` shape with sub-agents directly (structural cuts first, then line-level; deletion gets the last word), no dynamic workflow.
 
 This is the lighter, faster default for most "trim this one file/prompt/skill" asks.
 


### PR DESCRIPTION
## Problem

The direct-run path (added in #10 for small artifacts) told reviewers the bird's-eye pass only matters for multi-file trees:

> The bird's-eye/cross-file pass exists for multi-file trees; with one or two files there's almost nothing to see across them. Just run the algorithm yourself ... one reviewer per file proposing cuts/rewrites ...

This conflates two different altitudes. The **cross-file** pass really is moot for one file — but the **structural** pass (does each section/block/requirement deserve to exist?) is not, and it's where the deepest cuts live. The wording routes you straight to line-level copy review, so a single dense file (a landing page, a long doc) gets a ~1% trim with every section accepted as-is — the opposite of an Elon pass.

This surfaced dogfooding the skill on the `hands-on-deck` landing page: first run cut 1445→1427 lines (sentences only); re-run at the structural altitude cut 13 sections → 6.

## Change

Rewrites the direct-run paragraph to:
- separate *cross-file* (moot for one file) from *structural* (always applies)
- instruct: attack structure before copy — delete/merge whole sections first, then simplify survivors
- add a named tripwire: **"treating the existing structure as fixed and only trimming sentences inside it — a 1% pass, not an Elon pass"**

One paragraph, no behavior change to the workflow path. Version bump 0.2.0 → 0.2.1 (plugin.json + marketplace.json per marketplace convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)